### PR TITLE
Add ALIAS Support

### DIFF
--- a/lib/fog/dynect/requests/dns/delete_record.rb
+++ b/lib/fog/dynect/requests/dns/delete_record.rb
@@ -5,7 +5,7 @@ module Fog
         # Delete a record
         #
         # ==== Parameters
-        # * type<~String> - type of record in ['AAAA', 'ANY', 'A', 'CNAME', 'DHCID', 'DNAME', 'DNSKEY', 'DS', 'KEY', 'LOC', 'MX', 'NSA', 'NS', 'PTR', 'PX', 'RP', 'SOA', 'SPF', 'SRV', 'SSHFP', 'TXT']
+        # * type<~String> - type of record in ['AAAA', 'ALIAS', 'ANY', 'A', 'CNAME', 'DHCID', 'DNAME', 'DNSKEY', 'DS', 'KEY', 'LOC', 'MX', 'NSA', 'NS', 'PTR', 'PX', 'RP', 'SOA', 'SPF', 'SRV', 'SSHFP', 'TXT']
         # * zone<~String> - zone of record
         # * fqdn<~String> - fqdn of record
         # * record_id<~String> - id of record

--- a/lib/fog/dynect/requests/dns/get_record.rb
+++ b/lib/fog/dynect/requests/dns/get_record.rb
@@ -24,10 +24,10 @@ module Fog
       class Mock
         def get_record(type, zone, fqdn, options = {})
           raise ArgumentError unless [
-            'AAAA', 'ANY', 'A', 'CNAME',
-            'DHCID', 'DNAME', 'DNSKEY',
-            'DS', 'KEY', 'LOC', 'MX',
-            'NSA', 'NS', 'PTR', 'PX',
+            'AAAA', 'ALIAS' ,'ANY', 'A',
+            'CNAME', 'DHCID', 'DNAME',
+            'DNSKEY', 'DS', 'KEY', 'LOC',
+            'MX', 'NSA', 'NS', 'PTR', 'PX',
             'RP', 'SOA', 'SPF', 'SRV',
             'SSHFP', 'TXT'
           ].include? type

--- a/lib/fog/dynect/requests/dns/get_record.rb
+++ b/lib/fog/dynect/requests/dns/get_record.rb
@@ -5,7 +5,7 @@ module Fog
         # List records of a given type
         #
         # ==== Parameters
-        # * type<~String> - type of record in ['AAAA', 'ANY', 'A', 'CNAME', 'DHCID', 'DNAME', 'DNSKEY', 'DS', 'KEY', 'LOC', 'MX', 'NSA', 'NS', 'PTR', 'PX', 'RP', 'SOA', 'SPF', 'SRV', 'SSHFP', 'TXT']
+        # * type<~String> - type of record in ['AAAA', 'ALIAS', 'ANY', 'A', 'CNAME', 'DHCID', 'DNAME', 'DNSKEY', 'DS', 'KEY', 'LOC', 'MX', 'NSA', 'NS', 'PTR', 'PX', 'RP', 'SOA', 'SPF', 'SRV', 'SSHFP', 'TXT']
         # * zone<~String> - name of zone to lookup
         # * fqdn<~String> - name of fqdn to lookup
         # * options<~Hash>:

--- a/lib/fog/dynect/requests/dns/post_record.rb
+++ b/lib/fog/dynect/requests/dns/post_record.rb
@@ -5,7 +5,7 @@ module Fog
         # Create a record
         #
         # ==== Parameters
-        # * type<~String> - type of record in ['AAAA', 'ANY', 'A', 'CNAME', 'DHCID', 'DNAME', 'DNSKEY', 'DS', 'KEY', 'LOC', 'MX', 'NSA', 'NS', 'PTR', 'PX', 'RP', 'SOA', 'SPF', 'SRV', 'SSHFP', 'TXT']
+        # * type<~String> - type of record in ['AAAA', 'ALIAS', 'ANY', 'A', 'CNAME', 'DHCID', 'DNAME', 'DNSKEY', 'DS', 'KEY', 'LOC', 'MX', 'NSA', 'NS', 'PTR', 'PX', 'RP', 'SOA', 'SPF', 'SRV', 'SSHFP', 'TXT']
         # * zone<~String> - zone of record
         # * rdata<~Hash> - rdata for record
         # * options<~Hash>: (options vary by type, listing below includes common parameters)


### PR DESCRIPTION
https://help.dyn.com/enabling-alias-records-in-managed-dns/ 

ALIAS records can be enabled, this fix should allow us to use ALIAS records out of the box. 
