### PR TITLE
dyn api version 3.7.0

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -68,7 +68,7 @@ module Fog
           @path               = options[:path]             || '/REST'
           @persistent         = options[:persistent]       || false
           @scheme             = options[:scheme]           || 'https'
-          @version            = options[:version]          || '3.5.2'
+          @version            = options[:version]          || '3.7.0'
           @job_poll_timeout   = options[:job_poll_timeout] || 10
           @connection = Fog::XML::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
         end


### PR DESCRIPTION
we need to bump to version 3.7.0 of the api in order to manage ALIAS records
