### PR TITLE
allow version option

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -2,7 +2,7 @@ module Fog
   module DNS
     class Dynect < Fog::Service
       requires :dynect_customer, :dynect_username, :dynect_password
-      recognizes :timeout, :persistent, :job_poll_timeout
+      recognizes :timeout, :persistent, :job_poll_timeout, :version
       recognizes :provider # remove post deprecation
 
       model_path 'fog/dynect/models/dns'


### PR DESCRIPTION
as a complement to https://github.com/fog/fog-dynect/pull/8 ... this PR allows the version to be specified by the consumer... without producing a warning

wdyt @plribeiro3000 ?
