### PR TITLE
recognize version option

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -2,7 +2,7 @@ module Fog
   module DNS
     class Dynect < Fog::Service
       requires :dynect_customer, :dynect_username, :dynect_password
-      recognizes :timeout, :persistent, :job_poll_timeout
+      recognizes :timeout, :persistent, :job_poll_timeout, :version
       recognizes :provider # remove post deprecation
 
       model_path 'fog/dynect/models/dns'


### PR DESCRIPTION
since fog-dynect locks itself to an API version, it's sometimes necessary to be able to override the version used to take advantage of newer features (eg. CAA records were introduced in 3.7.6, but fog-dynect is locked to 3.7.0)

currently, passing a `version` option to `Fog::DNS.new` results in a warning `[fog][WARNING] Unrecognized arguments: version` - but it *is* in fact supported

this PR adds version to the recognized options to avoid the warning
