### PR TITLE
bump Dyn API version to 3.7.13

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -68,7 +68,7 @@ module Fog
           @path               = options[:path]             || '/REST'
           @persistent         = options[:persistent]       || false
           @scheme             = options[:scheme]           || 'https'
-          @version            = options[:version]          || '3.7.0'
+          @version            = options[:version]          || '3.7.13'
           @job_poll_timeout   = options[:job_poll_timeout] || 10
           @connection = Fog::XML::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
         end


### PR DESCRIPTION
This PR bumps the dyn api version used, so that we get the latest (at least for now) bugfixes and features -- eg. support for CAA records.

Based on https://manage.dynect.net/help/changelog.html, I don't see anything that should be a breaking change.

Here's the documented API changes for reference.

**Version 3.7.11**
- /REST/ExtNameserver/ GET will no longer return entries for deleted zones

**Version 3.7.6**
- Suport (sic) for the CAA record type

**Version 3.7.3**
- Converted job_id from an int to a string in SOAP calls to allow ids in excess of 32 bit integer maximum.

**Version 3.7.2**
- External nameserver configuration is now available through the API

**Version 3.7.1**
- Internal feature support

NOTE: I've bumped the gem version to 0.3.2 (and am assuming that #20 is merged before this one)
