### PR TITLE
Deprecate Fog::DNS::Dynect

### DIFF
--- a/lib/fog/bin/dynect.rb
+++ b/lib/fog/bin/dynect.rb
@@ -3,7 +3,7 @@ class Dynect < Fog::Bin
     def class_for(key)
       case key
       when :dns
-        Fog::DNS::Dynect
+        Fog::Dynect::DNS
       else
         raise ArgumentError, "Unrecognized service: #{key}"
       end

--- a/lib/fog/dynect.rb
+++ b/lib/fog/dynect.rb
@@ -5,14 +5,12 @@ require 'fog/json'
 require 'fog/xml'
 
 module Fog
-  module DNS
-    autoload :Dynect, File.expand_path('../dynect/dns', __FILE__)
-  end
-
   module Dynect
     extend Fog::Provider
 
     autoload :VERSION, File.expand_path('../dynect/version', __FILE__)
+
+    autoload :DNS, File.expand_path('../dynect/dns', __FILE__)
 
     service(:dns, 'DNS')
 

--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect < Fog::Service
+  module Dynect
+    class DNS < Fog::Service
       requires :dynect_customer, :dynect_username, :dynect_password
       recognizes :timeout, :persistent, :job_poll_timeout, :version
       recognizes :provider # remove post deprecation
@@ -149,6 +149,19 @@ module Fog
 
           response
         end
+      end
+    end
+  end
+
+  # @deprecated
+  module DNS
+    # @deprecated
+    class Dynect < Fog::Dynect::DNS
+      # @deprecated
+      # @overrides Fog::Service.new (from the fog-core gem)
+      def self.new(*)
+        Fog::Logger.deprecation 'Fog::DNS::Dynect is deprecated, please use Fog::Dynect::DNS.'
+        super
       end
     end
   end

--- a/lib/fog/dynect/models/dns/record.rb
+++ b/lib/fog/dynect/models/dns/record.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Record < Fog::Model
         extend Fog::Deprecation
 

--- a/lib/fog/dynect/models/dns/records.rb
+++ b/lib/fog/dynect/models/dns/records.rb
@@ -1,12 +1,12 @@
 require 'fog/dynect/models/dns/record'
 
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Records < Fog::Collection
         attribute :zone
 
-        model Fog::DNS::Dynect::Record
+        model Fog::Dynect::DNS::Record
 
         def all(options = {})
           requires :zone

--- a/lib/fog/dynect/models/dns/zone.rb
+++ b/lib/fog/dynect/models/dns/zone.rb
@@ -1,8 +1,8 @@
 require 'fog/dynect/models/dns/records'
 
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Zone < Fog::Model
         identity  :domain
 
@@ -35,7 +35,7 @@ module Fog
         end
 
         def records
-          @records ||= Fog::DNS::Dynect::Records.new(:zone => self, :service => service)
+          @records ||= Fog::Dynect::DNS::Records.new(:zone => self, :service => service)
         end
 
         def nameservers

--- a/lib/fog/dynect/models/dns/zones.rb
+++ b/lib/fog/dynect/models/dns/zones.rb
@@ -1,10 +1,10 @@
 require 'fog/dynect/models/dns/zone'
 
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Zones < Fog::Collection
-        model Fog::DNS::Dynect::Zone
+        model Fog::Dynect::DNS::Zone
 
         def all
           data = service.get_zone.body['data'].map do |zone|

--- a/lib/fog/dynect/requests/dns/delete_record.rb
+++ b/lib/fog/dynect/requests/dns/delete_record.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Delete a record
         #
@@ -22,9 +22,9 @@ module Fog
 
       class Mock
         def delete_record(type, zone, fqdn, record_id)
-          raise Fog::DNS::Dynect::NotFound unless zone = self.data[:zones][zone]
+          raise Fog::Dynect::DNS::NotFound unless zone = self.data[:zones][zone]
 
-          raise Fog::DNS::Dynect::NotFound unless zone[:records][type].find { |record| record[:fqdn] == fqdn && record[:record_id] == record_id.to_i }
+          raise Fog::Dynect::DNS::NotFound unless zone[:records][type].find { |record| record[:fqdn] == fqdn && record[:record_id] == record_id.to_i }
 
           zone[:records_to_delete] << {
             :type => type,

--- a/lib/fog/dynect/requests/dns/delete_zone.rb
+++ b/lib/fog/dynect/requests/dns/delete_zone.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Delete a zone
         #

--- a/lib/fog/dynect/requests/dns/get_all_records.rb
+++ b/lib/fog/dynect/requests/dns/get_all_records.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Get one or more node lists
         #

--- a/lib/fog/dynect/requests/dns/get_node_list.rb
+++ b/lib/fog/dynect/requests/dns/get_node_list.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Get one or more node lists
         #

--- a/lib/fog/dynect/requests/dns/get_record.rb
+++ b/lib/fog/dynect/requests/dns/get_record.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # List records of a given type
         #

--- a/lib/fog/dynect/requests/dns/get_zone.rb
+++ b/lib/fog/dynect/requests/dns/get_zone.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Get one or more zones
         #

--- a/lib/fog/dynect/requests/dns/post_record.rb
+++ b/lib/fog/dynect/requests/dns/post_record.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Create a record
         #

--- a/lib/fog/dynect/requests/dns/post_session.rb
+++ b/lib/fog/dynect/requests/dns/post_session.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         def post_session
           request(

--- a/lib/fog/dynect/requests/dns/post_zone.rb
+++ b/lib/fog/dynect/requests/dns/post_zone.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Create a zone
         #

--- a/lib/fog/dynect/requests/dns/put_record.rb
+++ b/lib/fog/dynect/requests/dns/put_record.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Update or replace a record
         #

--- a/lib/fog/dynect/requests/dns/put_zone.rb
+++ b/lib/fog/dynect/requests/dns/put_zone.rb
@@ -1,6 +1,6 @@
 module Fog
-  module DNS
-    class Dynect
+  module Dynect
+    class DNS
       class Real
         # Update a zone
         #


### PR DESCRIPTION
Fixes fog-core deprecation warning

```
[fog][DEPRECATION] Unable to load Fog::Dynect::DNS
[fog][DEPRECATION] Falling back to deprecated constant Fog::DNS::Dynect. The preferred format of service provider constants has changed from service::provider to provider::service. Please update this service provider to use the preferred format.
```

Ref https://github.com/fog/fog-aws/issues/466